### PR TITLE
Update, fix bug finding namespace

### DIFF
--- a/Controller/Automations/WorkflowXHR.php
+++ b/Controller/Automations/WorkflowXHR.php
@@ -174,7 +174,7 @@ class WorkflowXHR extends AbstractController
                         'id' => $item->getId(),
                         'name' => $item->getCode(),
                     ];
-                }, $this->getDoctrine()->getRepository("Webkul\\UVDesk\\CoreFrameworkBundle\\" . ucfirst($entity))->findAll()));
+                }, $this->getDoctrine()->getRepository("Webkul\\UVDesk\\CoreFrameworkBundle\\Entity\\" . ucfirst($entity))->findAll()));
 
                 break;
             default:


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
The namespaces for entities could not be found when configuring workflows, e.g. TicketStatus or TicketPriority.

### 2. What does this change do, exactly?
Fixes the namespace to get the repository from by adding "Entity" to the string.

### 3. Please link to the relevant issues (if any).
-